### PR TITLE
Remove pg_hba from helper

### DIFF
--- a/manifests/postgresql.pp
+++ b/manifests/postgresql.pp
@@ -19,8 +19,4 @@ class helper::postgresql {
   $postgresql_hba_rules = hiera_hash('postgresql::hba_rules', {})
   create_resources(::postgresql::server::pg_hba_rule, $postgresql_hba_rules)
 
-  # Config lines
-  $postgresql_config_entries = hiera_hash('postgresql::server::config_entries', {})
-  create_resources(::postgresql::server::config_entry, $postgresql_config_entries)
-
 }


### PR DESCRIPTION
This feature is now part of puppetlabs/postgresql v6.2.0

Note: this is backwards incompatible, so unless postgresql module supports this directly, this **will break** pg_hba!